### PR TITLE
Cleaning up documentation and fixing areas vector bug

### DIFF
--- a/R/incidence.from.congress.R
+++ b/R/incidence.from.congress.R
@@ -5,7 +5,7 @@
 #'
 #' @param session numeric: the session of congress
 #' @param types vector: types of bills to include. May be any combination of c("s", "sres", "sjres", "sconres") OR any combination of c("hr", "hres", "hjres", "hconres").
-#' @param areas string: policy areas of bills to include (see details)
+#' @param areas vector: policy areas of bills to include (see details)
 #' @param nonvoting boolean: should non-voting members be included
 #' @param weighted boolean: should sponsor-bill edges have a weight of 2, but cosponsor-bill edges have a weight of 1
 #' @param format string: format of output, one of c("data", "igraph")
@@ -84,13 +84,13 @@ incidence.from.congress <- function(session = NULL, types = NULL, areas = "all",
 
       #Check area, add bill if relevant
       area <- tolower(xml2::xml_text(xml2::xml_find_first(bill, ".//policyArea")))
-      if (areas=="all" | area %in% areas) {
+      if (area %in% c(areas, "all")) {
 
       #Bill characteristics
-      
+
         #Old XML tags (https://github.com/usgpo/bill-status/issues/200)
         number <- paste0(xml2::xml_text(xml2::xml_find_first(bill, ".//billType")),xml2::xml_text(xml2::xml_find_first(bill, ".//billNumber")))
-        
+
         #If it doesn't work, use new XML tags (https://github.com/usgpo/bill-status/issues/200)
         if (number == "NANA") {number <- paste0(xml2::xml_text(xml2::xml_find_first(bill, ".//type")),xml2::xml_text(xml2::xml_find_first(bill, ".//number")))}
 
@@ -152,13 +152,14 @@ incidence.from.congress <- function(session = NULL, types = NULL, areas = "all",
 
   #Display narrative if requested
   if (narrative) {
+
     version <- utils::packageVersion("incidentally")
     if (all(types %in% c("s", "sres", "sjres", "sconres"))) {who <- "Senators'"}
     if (all(types %in% c("hr", "hres", "hjres", "hconres"))) {who <- "Representatives'"}
-    if (format == "igraph" & areas == "all") {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate a bipartite graph recording ", who, " bill sponsorships during the ", session, " session of the US Congress.")}
-    if (format == "igraph" & areas != "all") {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate a bipartite graph recording ", who, " bill sponsorships during the ", session, " session of the US Congress. We restricted our focus to bills in the following policy areas: ", paste(areas, collapse=', '), ".")}
-    if (format == "data" & areas == "all") {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate an incidence matrix recording ", who, " bill sponsorships during the ", session, " session of the US Congress.")}
-    if (format == "data" & areas != "all") {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate an incidence matrix recording ", who, " bill sponsorships during the ", session, " session of the US Congress. We restricted our focus to bills in the following policy areas: ", paste(areas, collapse=', '), ".")}
+    if (format == "igraph" & "all" %in% areas) {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate a bipartite graph recording ", who, " bill sponsorships during the ", session, " session of the US Congress.")}
+    if (format == "igraph" & !("all" %in% areas)) {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate a bipartite graph recording ", who, " bill sponsorships during the ", session, " session of the US Congress. We restricted our focus to bills in the following policy areas: ", paste(areas, collapse=', '), ".")}
+    if (format == "data" & "all" %in% areas) {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate an incidence matrix recording ", who, " bill sponsorships during the ", session, " session of the US Congress.")}
+    if (format == "data" & !("all" %in% areas)) {text <- paste0("We used the incidentally package for R (v", version, "; Neal, 2022) to generate an incidence matrix recording ", who, " bill sponsorships during the ", session, " session of the US Congress. We restricted our focus to bills in the following policy areas: ", paste(areas, collapse=', '), ".")}
     message("")
     message("=== Suggested manuscript text and citations ===")
     message(text)

--- a/vignettes/congress.Rmd
+++ b/vignettes/congress.Rmd
@@ -26,7 +26,7 @@ par(mar = c(0, 0, 1, 0))
 
 # Table of Contents {#toc}
 
-[<img src='../man/figures/logo.png' align="right" height="250" />](https://www.zacharyneal.com/backbone)
+[<img src='../man/figures/logo.png' align="right" height="250" />](https://www.zacharyneal.com/incidence)
 
 1. [Introduction](#introduction)
     a. [Welcome](#welcome)
@@ -46,7 +46,7 @@ For a more general introduction to the `incidentally` package, see [the main vig
 
 **Neal, Z. P. (2022). incidentally: An R package to generate incidence matrices and bipartite graphs. *OSF Preprints*. [https://doi.org/10.31219/osf.io/ectms](https://doi.org/10.31219/osf.io/ectms)**
 
-If you have questions about the incidentally package or would like an incidentally hex sticker, please contact the maintainer Zachary Neal by email ([zpneal\@msu.edu](mailto:zpneal@msu.edu)) or via Mastodon ([\@zpneal@mastodon.social](https://mastodon.social/@zpneal)). Please report bugs in the backbone package at [https://github.com/zpneal/incidentally/issues](https://github.com/zpneal/backbone/issues).
+If you have questions about the incidentally package or would like an incidentally hex sticker, please contact the maintainer Zachary Neal by email ([zpneal\@msu.edu](mailto:zpneal@msu.edu)) or via Mastodon ([\@zpneal@mastodon.social](https://mastodon.social/@zpneal)). Please report bugs in the incidence package at [https://github.com/zpneal/incidentally/issues](https://github.com/zpneal/incidentally/issues).
 
 ## The US legislative process {#process}
 In the US Congress, bills may become laws through a multi-step legislative process:

--- a/vignettes/incidentally.Rmd
+++ b/vignettes/incidentally.Rmd
@@ -26,7 +26,7 @@ par(mar = c(0, 0, 1, 0))
 
 # Table of Contents {#toc}
 
-[<img src='../man/figures/logo.png' align="right" height="250" />](https://www.zacharyneal.com/backbone)
+[<img src='../man/figures/logo.png' align="right" height="250" />](https://www.zacharyneal.com/incidentally)
 
 1. [Introduction](#introduction)
     a. [Welcome](#welcome)
@@ -54,7 +54,7 @@ The `incidentally` package can be cited as:
 
 **Neal, Z. P. (2022). incidentally: An R package to generate incidence matrices and bipartite graphs. *OSF Preprints*. [https://doi.org/10.31219/osf.io/ectms](https://doi.org/10.31219/osf.io/ectms)**
 
-For additional resources on the incidentally package, please see [https://www.rbackbone.net/](https://www.zacharyneal.com/backbone). If you have questions about the incidentally package or would like an incidentally hex sticker, please contact the maintainer Zachary Neal by email ([zpneal\@msu.edu](mailto:zpneal@msu.edu)) or via Mastodon ([\@zpneal@mastodon.social](https://mastodon.social/@zpneal)). Please report bugs in the backbone package at [https://github.com/zpneal/incidentally/issues](https://github.com/zpneal/backbone/issues).
+For additional resources on the incidentally package, please see [https://www.zacharyneal.com/incidentally](https://www.zacharyneal.com/incidentally). If you have questions about the incidentally package or would like an incidentally hex sticker, please contact the maintainer Zachary Neal by email ([zpneal\@msu.edu](mailto:zpneal@msu.edu)) or via Mastodon ([\@zpneal@mastodon.social](https://mastodon.social/@zpneal)). Please report bugs in the incidentally package at [https://github.com/zpneal/incidentally/issues](https://github.com/zpneal/incidentally/issues).
 
 ## What are incidence matrices? {#what}
 An *incidence* matrix is a binary $r \times c$ matrix **I** that records associations between $r$ objects represented by rows and $c$ objects represented by columns. In this matrix, $I_{ij} = 1$ if the i<sup>th</sup> row object is associated with the j<sup>th</sup> column object, and otherwise $I_{ij} = 0$. An incidence matrix can be used to represent a *bipartite*, *two-mode*, or *affiliation* network/graph, in which the rows represent one type of node, and the columns represent another type of node (e.g., people who author papers, species living in habitats) [@latapy2008]. An incidence matrix can also represent a *hypergraph*, in which each column represents a hyperedge and identifies the nodes that it connects.
@@ -92,7 +92,7 @@ The incidentally package offers multiple incidence matrix-generating functions t
 
 * [`curveball()`](#random) randomizes an incidence matrix or bipartite graph while preserving in marginal/degree sequence, and [`add.blocks()`](#block) adds a block structure or planted partition to an existing incidence matrix or bipartite graph.
 
-* `incidence.from.congress()` constructs an incidence matrix or bipartite graph representing US Congress legislators' sponsorship of bills. For a detailed description of this function, and its use with the `backbone` package to generate political networks, see this [companion vignette](congress.html).
+* `incidence.from.congress()` constructs an incidence matrix or bipartite graph representing US Congress legislators' sponsorship of bills. For a detailed description of this function, and its use with the `incidence` package to generate political networks, see this [companion vignette](congress.html).
 
 [back to Table of Contents](#toc)
 


### PR DESCRIPTION
The big thing here is that there was an issue in `incidence.from.congress` and how it treated the `areas` argument. If you gave it a vector of length greater than 1 then it threw an error because some of the code checking to see if `areas` was "all" expected a single string, not a vector. 

I also think that some of the documentation made references to your `backbone` package that should have been references to `incidentally` and cleaned those up. Not positive on that one though. 

Using this to pull some data for an assignment in my SNA class. Thanks for making it. 